### PR TITLE
Update requirements_py2.txt

### DIFF
--- a/python/requirements_py2.txt
+++ b/python/requirements_py2.txt
@@ -8,7 +8,6 @@ idna==2.1
 ipaddress==1.0.17
 lxml==3.6.4
 parsel==1.0.3
-pkg-resources==0.0.0
 pyasn1==0.1.9
 pyasn1-modules==0.0.8
 pycparser==2.14


### PR DESCRIPTION
Ubuntu adds "pkg-resources==0.0.0" incorrectly when using "pip freeze", causing the installation to fail